### PR TITLE
Make QED initial match a desired target

### DIFF
--- a/src/QED.jl
+++ b/src/QED.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module QED
 
 using FiniteElementHermite


### PR DESCRIPTION
In QED, the <∇ρ²/R²> is computed on the fly to give the desired <Jt/R>. This change allows the user to specify a desired total plasma current, so the edge value of <∇ρ²/R²> gets modified to match this exactly.