### PR TITLE
Improve performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ FiniteElementHermite = "6ce10167-d368-4c0e-af34-9787cdd175e5"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
@@ -20,4 +21,5 @@ DataInterpolations = "7, 8"
 FiniteElementHermite = "0.2, 1"
 ForwardDiff = "0.10"
 JSON = "0.21"
+LinearSolve = "3.15.0"
 Requires = "1"

--- a/src/QED.jl
+++ b/src/QED.jl
@@ -6,7 +6,8 @@ import DataInterpolations: DataInterpolations, ExtrapolationType
 import ForwardDiff
 import JSON
 using ArgParse
-import LinearAlgebra: mul!, rmul!, Diagonal
+import LinearAlgebra: mul!, rmul!, Diagonal, axpy!
+import LinearSolve
 
 using Requires
 

--- a/src/current.jl
+++ b/src/current.jl
@@ -58,6 +58,6 @@ end
 Return the loop voltage associated with the non-inductive current for QED_state `QI`
 with (callable) resitivity `η` at `ρ=x`
 """
-function Vni(QI::QED_state, η, x)
+@inline function Vni(QI::QED_state, η::F, x) where {F}
     return 2π * η(x) * QI.JBni(x) / (QI.F(x) * QI.fsa_R⁻²(x))
 end

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -202,13 +202,17 @@ end
 Return a cubic-Hermite finite-element interpolation of the resistivity `η` on grid `rho`
 `use_log=true` (default) interpolates on the log of the resistivity
 """
-function η_FE(rho::AbstractVector{<:Real}, η::AbstractVector{<:Real}; use_log::Bool=true)
-    rtype = typeof(η[1])
+function η_FE(rho::AbstractVector{S}, η::AbstractVector{T}; use_log::Bool=true) where {S<:Real,T<:Real}
+    rhot = S.(rho)
+    return η_FE(rhot, η; use_log)
+end
+
+function η_FE(rho::AbstractVector{T}, η::AbstractVector{T}; use_log::Bool=true) where {T<:Real}
     if use_log
-        log_η = FE(rtype.(rho), log.(η))
+        log_η = FE(rho, log.(η))
         return x -> exp(log_η(x))
     else
-        return FE(rtype.(rho), η)
+        return FE(rho, η)
     end
 end
 


### PR DESCRIPTION
- Use LinearSolve
- Use `axpy!` for efficient broadcasting over BandedMatrices
- Force `define_Sni` to [specialize](https://gensoft.pasteur.fr/docs/julia/1.4.1/manual/performance-tips.html#Be-aware-of-when-Julia-avoids-specializing-1) on `η`