### PR TITLE
Make fsa_∇ρ²_R² work properly on-axis

### DIFF
--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -17,8 +17,13 @@ QED_state(ρ, dΡ_dρ, B₀, fsa_R⁻², F, dV_dρ, ι, JtoR, χ, JBni, _ι_eq) 
 
 @inline dΦ_dρ(QI::QED_state, x::Real) = 2π * QI.B₀ * QI.dΡ_dρ^2 * x
 
-@inline function fsa_∇ρ²_R²(QI::QED_state, r::Real; ε=1e-3)
-    r == 0 && return 2 * fsa_∇ρ²_R²(QI, ε) - fsa_∇ρ²_R²(QI, 2ε) # Linearly extrapolate to axis
+@inline function fsa_∇ρ²_R²(QI::QED_state, r::Real; ε=1e-6)
+    if r < ε
+        fε = fsa_∇ρ²_R²(QI, ε; ε)
+        f2ε = fsa_∇ρ²_R²(QI, 2 * ε; ε)
+        m = (f2ε - fε) / ε
+        return fε + m * (r - ε)  # Linearly extrapolate to
+    end
     return QI.χ(r) / (QI.dV_dρ(r) * QI._ι_eq(r) * dΦ_dρ(QI, r))
 end
 


### PR DESCRIPTION
Bug revealed by ForwardDiff v1 upgrade in 847c5c03b953f6c14a11bc71374ff7e801dfea82