### PR TITLE
Fix fsa_∇ρ²_R² near magnetic axis

### DIFF
--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -17,14 +17,12 @@ QED_state(ρ, dΡ_dρ, B₀, fsa_R⁻², F, dV_dρ, ι, JtoR, χ, JBni, _ι_eq) 
 
 @inline dΦ_dρ(QI::QED_state, x::Real) = 2π * QI.B₀ * QI.dΡ_dρ^2 * x
 
-@inline function fsa_∇ρ²_R²(QI::QED_state, r::Real; ε=1e-6)
+@inline function fsa_∇ρ²_R²(QI::QED_state, r::Real; ε=1e-3)
     if r < ε
-        fε = fsa_∇ρ²_R²(QI, ε; ε)
-        f2ε = fsa_∇ρ²_R²(QI, 2 * ε; ε)
-        m = (f2ε - fε) / ε
-        return fε + m * (r - ε)  # Linearly extrapolate to
+        return max(fsa_∇ρ²_R²(QI, ε; ε), 1e-4)
     end
-    return QI.χ(r) / (QI.dV_dρ(r) * QI._ι_eq(r) * dΦ_dρ(QI, r))
+    val = QI.χ(r) / (QI.dV_dρ(r) * QI._ι_eq(r) * dΦ_dρ(QI, r))
+    return max(val, 1e-4)
 end
 
 @inline function D_fsa_∇ρ²_R²(QI::QED_state, x::Real)

--- a/src/initialize.jl
+++ b/src/initialize.jl
@@ -19,7 +19,10 @@ QED_state(ρ, dΡ_dρ, B₀, fsa_R⁻², F, dV_dρ, ι, JtoR, χ, JBni, _ι_eq) 
 
 @inline function fsa_∇ρ²_R²(QI::QED_state, r::Real; ε=1e-3)
     if r < ε
-        return max(fsa_∇ρ²_R²(QI, ε; ε), 1e-4)
+        fε = fsa_∇ρ²_R²(QI, ε; ε)
+        f2ε = fsa_∇ρ²_R²(QI, 2 * ε; ε)
+        m = (f2ε - fε) / ε
+        return max(fε + m * (r - ε), 1e-4)
     end
     val = QI.χ(r) / (QI.dV_dρ(r) * QI._ι_eq(r) * dΦ_dρ(QI, r))
     return max(val, 1e-4)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                
  `fsa_∇ρ²_R²` computes the flux surface averaged metric `<|∇ρ|²/R²>` used in the QED transport diffusion equations:
                                                                                                                                                                                                                                                                                
  ```julia
  χ(r) / (dV_dρ(r) * ι_eq(r) * dΦ_dρ(r))                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                
  Near the magnetic axis (ρ→0), all denominator terms approach zero. Mathematically their ratio should remain finite, but numerically the cancellation can break down — particularly during rapid transients (e.g., fast input power ramps) where the equilibrium geometry near 
  the axis is not well-resolved. In these cases, the interpolated quantities (χ, dV_dρ, ι_eq) don't cancel cleanly, causing fsa_∇ρ²_R² to blow up or go negative, which crashes the QED solver.                                                                                 
                                                                                                                                                                                                                                                                                
  Changes                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                
  - Increased ε from 1e-6 to 1e-3: The previous cutoff was too small to avoid the numerically unstable region near the axis                                                                                                                                                     
  - Constant extrapolation instead of linear: The previous linear extrapolation from ε could still produce negative values when the slope was steep                                                                                                                             
  - Positive floor of 1e-4 for all ρ values: Safety net ensuring the metric never goes negative, which is unphysical (<|∇ρ|²/R²> is a squared quantity averaged over a flux surface and must be positive)                                                                       
                                                                                                                                                                                                                                                                                
  Test plan                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                
  - Verify QED solver no longer crashes near magnetic axis during rapid power transients                                                                                                                                                                                        
  - Run postdictive simulation to confirm fix does not affect converged results      